### PR TITLE
Add Monte Carlo option pricing dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
-# :earth_americas: GDP dashboard template
+# :chart_with_upwards_trend: Monte Carlo Option Dashboard
 
-A simple Streamlit app showing the GDP of different countries in the world.
+A simple Streamlit application that prices European call and put options using
+Monte Carlo simulation. The app lets you explore the impact of different
+parameters and visualizes sample price paths and the distribution of terminal
+prices.
 
-[![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://gdp-dashboard-template.streamlit.app/)
-
-### How to run it on your own machine
+## How to run it on your own machine
 
 1. Install the requirements
 
    ```
-   $ pip install -r requirements.txt
+   pip install -r requirements.txt
    ```
 
 2. Run the app
 
    ```
-   $ streamlit run streamlit_app.py
+   streamlit run streamlit_app.py
    ```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 pandas
+numpy

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,151 +1,64 @@
-import streamlit as st
+import numpy as np
 import pandas as pd
-import math
-from pathlib import Path
+import streamlit as st
 
-# Set the title and favicon that appear in the Browser's tab bar.
 st.set_page_config(
-    page_title='GDP dashboard',
-    page_icon=':earth_americas:', # This is an emoji shortcode. Could be a URL too.
+    page_title="Option Monte Carlo",
+    page_icon=":chart_with_upwards_trend:",
 )
 
-# -----------------------------------------------------------------------------
-# Declare some useful functions.
+st.title("Monte Carlo Option Pricing")
 
-@st.cache_data
-def get_gdp_data():
-    """Grab GDP data from a CSV file.
+col1, col2 = st.columns(2)
 
-    This uses caching to avoid having to read the file every time. If we were
-    reading from an HTTP endpoint instead of a file, it's a good idea to set
-    a maximum age to the cache with the TTL argument: @st.cache_data(ttl='1d')
-    """
+with col1:
+    s0 = st.number_input("Initial stock price", value=100.0, min_value=0.0)
+    k = st.number_input("Strike price", value=100.0, min_value=0.0)
+    t = st.number_input("Time to maturity (years)", value=1.0, min_value=0.01)
 
-    # Instead of a CSV on disk, you could read from an HTTP endpoint here too.
-    DATA_FILENAME = Path(__file__).parent/'data/gdp_data.csv'
-    raw_gdp_df = pd.read_csv(DATA_FILENAME)
+with col2:
+    r = st.number_input("Risk-free rate", value=0.05)
+    sigma = st.number_input("Volatility", value=0.2, min_value=0.0)
+    simulations = st.number_input("Simulations", value=10000, step=1000, min_value=1)
+    steps = st.number_input("Steps per simulation", value=252, step=1, min_value=1)
 
-    MIN_YEAR = 1960
-    MAX_YEAR = 2022
+run = st.button("Run simulation")
 
-    # The data above has columns like:
-    # - Country Name
-    # - Country Code
-    # - [Stuff I don't care about]
-    # - GDP for 1960
-    # - GDP for 1961
-    # - GDP for 1962
-    # - ...
-    # - GDP for 2022
-    #
-    # ...but I want this instead:
-    # - Country Name
-    # - Country Code
-    # - Year
-    # - GDP
-    #
-    # So let's pivot all those year-columns into two: Year and GDP
-    gdp_df = raw_gdp_df.melt(
-        ['Country Code'],
-        [str(x) for x in range(MIN_YEAR, MAX_YEAR + 1)],
-        'Year',
-        'GDP',
-    )
+if run:
+    steps = int(steps)
+    simulations = int(simulations)
 
-    # Convert years from string to integers
-    gdp_df['Year'] = pd.to_numeric(gdp_df['Year'])
+    dt = t / steps
+    z = np.random.standard_normal((steps, simulations))
+    price_paths = np.zeros_like(z)
+    price_paths[0] = s0
 
-    return gdp_df
-
-gdp_df = get_gdp_data()
-
-# -----------------------------------------------------------------------------
-# Draw the actual page
-
-# Set the title that appears at the top of the page.
-'''
-# :earth_americas: GDP dashboard
-
-Browse GDP data from the [World Bank Open Data](https://data.worldbank.org/) website. As you'll
-notice, the data only goes to 2022 right now, and datapoints for certain years are often missing.
-But it's otherwise a great (and did I mention _free_?) source of data.
-'''
-
-# Add some spacing
-''
-''
-
-min_value = gdp_df['Year'].min()
-max_value = gdp_df['Year'].max()
-
-from_year, to_year = st.slider(
-    'Which years are you interested in?',
-    min_value=min_value,
-    max_value=max_value,
-    value=[min_value, max_value])
-
-countries = gdp_df['Country Code'].unique()
-
-if not len(countries):
-    st.warning("Select at least one country")
-
-selected_countries = st.multiselect(
-    'Which countries would you like to view?',
-    countries,
-    ['DEU', 'FRA', 'GBR', 'BRA', 'MEX', 'JPN'])
-
-''
-''
-''
-
-# Filter the data
-filtered_gdp_df = gdp_df[
-    (gdp_df['Country Code'].isin(selected_countries))
-    & (gdp_df['Year'] <= to_year)
-    & (from_year <= gdp_df['Year'])
-]
-
-st.header('GDP over time', divider='gray')
-
-''
-
-st.line_chart(
-    filtered_gdp_df,
-    x='Year',
-    y='GDP',
-    color='Country Code',
-)
-
-''
-''
-
-
-first_year = gdp_df[gdp_df['Year'] == from_year]
-last_year = gdp_df[gdp_df['Year'] == to_year]
-
-st.header(f'GDP in {to_year}', divider='gray')
-
-''
-
-cols = st.columns(4)
-
-for i, country in enumerate(selected_countries):
-    col = cols[i % len(cols)]
-
-    with col:
-        first_gdp = first_year[first_year['Country Code'] == country]['GDP'].iat[0] / 1000000000
-        last_gdp = last_year[last_year['Country Code'] == country]['GDP'].iat[0] / 1000000000
-
-        if math.isnan(first_gdp):
-            growth = 'n/a'
-            delta_color = 'off'
-        else:
-            growth = f'{last_gdp / first_gdp:,.2f}x'
-            delta_color = 'normal'
-
-        st.metric(
-            label=f'{country} GDP',
-            value=f'{last_gdp:,.0f}B',
-            delta=growth,
-            delta_color=delta_color
+    for i in range(1, steps):
+        price_paths[i] = price_paths[i - 1] * np.exp(
+            (r - 0.5 * sigma**2) * dt + sigma * np.sqrt(dt) * z[i]
         )
+
+    terminal_prices = price_paths[-1]
+    call_payoff = np.maximum(terminal_prices - k, 0)
+    put_payoff = np.maximum(k - terminal_prices, 0)
+    discount = np.exp(-r * t)
+    call_price = discount * call_payoff.mean()
+    put_price = discount * put_payoff.mean()
+
+    st.subheader("Option prices")
+    col_call, col_put = st.columns(2)
+    col_call.metric("Call", f"{call_price:.2f}")
+    col_put.metric("Put", f"{put_price:.2f}")
+
+    st.subheader("Sample price paths")
+    sample_paths = price_paths[:, : min(10, simulations)]
+    st.line_chart(pd.DataFrame(sample_paths))
+
+    st.subheader("Distribution of terminal prices")
+    counts = pd.Series(terminal_prices).value_counts(bins=50).sort_index()
+    hist_df = pd.DataFrame({
+        'price': [interval.left for interval in counts.index],
+        'count': counts.values,
+    }).set_index('price')
+    st.bar_chart(hist_df)
+


### PR DESCRIPTION
## Summary
- replace GDP app with Monte Carlo option pricing simulation
- add numpy dependency and update README

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b06aaac2a0832391815d56e0ed90b3